### PR TITLE
Remove unwanted newline from Basic authorization

### DIFF
--- a/scrapy_proxies/randomproxy.py
+++ b/scrapy_proxies/randomproxy.py
@@ -67,7 +67,7 @@ class RandomProxy(object):
 
         request.meta['proxy'] = proxy_address
         if proxy_user_pass:
-            basic_auth = 'Basic ' + base64.encodestring(proxy_user_pass)
+            basic_auth = 'Basic ' + base64.encodestring(proxy_user_pass).strip()
             request.headers['Proxy-Authorization'] = basic_auth
         log.debug('Using proxy <%s>, %d proxies left' % (
                     proxy_address, len(self.proxies)))


### PR DESCRIPTION
Current code fails when querying https sites using user-pass proxies. As [this StackOverflow post suggests](http://stackoverflow.com/questions/36269843/scrapy-proxy-ip-does-not-work-with-https-returns-ssl-handshake-failure) the reason is an unwanted _new line character_ in the Authorization header. This pull request strips the header to remove unwanted characters.
