### PR TITLE
Fix for TypeError during base64 encode in Python 3.

### DIFF
--- a/scrapy_proxies/randomproxy.py
+++ b/scrapy_proxies/randomproxy.py
@@ -93,7 +93,7 @@ class RandomProxy(object):
 
         if proxy_user_pass:
             request.meta['proxy'] = proxy_address
-            basic_auth = 'Basic ' + base64.encodestring(proxy_user_pass).strip()
+            basic_auth = 'Basic ' + base64.b64encode(proxy_user_pass.encode()).decode()
             request.headers['Proxy-Authorization'] = basic_auth
         else:
             log.debug('Proxy user pass not found')


### PR DESCRIPTION
Changed base64.encodestring() to use base64.b64encode for Python 3 support. Was receiving a TypeError previously. You can read about it here on stackoverflow here: http://stackoverflow.com/questions/31144988/base64-encodestring-failing-in-python-3

I noticed it was also fixed kangoo13 in #16, but got lost.