### PR TITLE
Use original requested url to retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ checking for site logo or some other significant element.
 If not - retry request with dont_filter=True
 
     if not hxs.select('//get/site/logo'):
-        yield Request(url=response.url, dont_filter=True)
+        yield Request(url=response.meta.get('redirect_urls')[0], dont_filter=True)


### PR DESCRIPTION
If the page redirects to e.g. robots.txt or some other erroneous page, you'll want to retry the original requested url and not the redirected url.