### PR TITLE
Update randomproxy.py

### DIFF
--- a/scrapy_proxies/randomproxy.py
+++ b/scrapy_proxies/randomproxy.py
@@ -90,9 +90,9 @@ class RandomProxy(object):
             proxy_address = self.chosen_proxy
 
         proxy_user_pass = self.proxies[proxy_address]
-
+        request.meta['proxy'] = proxy_address
+        
         if proxy_user_pass:
-            request.meta['proxy'] = proxy_address
             basic_auth = 'Basic ' + base64.b64encode(proxy_user_pass.encode()).decode()
             request.headers['Proxy-Authorization'] = basic_auth
         else:


### PR DESCRIPTION
Bug fix. If user pass was missing then "proxy" was never in the request so you ended up using your own address.