### PR TITLE
Add compatibility with scrapinghub/splash virtual browser

### DIFF
--- a/scrapy_proxies/randomproxy.py
+++ b/scrapy_proxies/randomproxy.py
@@ -23,7 +23,7 @@ import random
 import base64
 import logging
 
-proxy_regex = r'(\w+://)([^:]+?:[^@]+?@)?(.+)'
+proxy_regex = r'(\w+://)([^:]+?:.+@)?(.+)'
 log = logging.getLogger('scrapy.proxies')
 
 class Mode:

--- a/scrapy_proxies/randomproxy.py
+++ b/scrapy_proxies/randomproxy.py
@@ -78,6 +78,9 @@ class RandomProxy(object):
         return cls(crawler.settings)
 
     def process_request(self, request, spider):
+        if self.mode < 0:
+            log.warning("Skipping Random Proxy selection(disabled)!")
+            return;
         # Don't overwrite with a random one (server-side state for IP)
         if 'proxy' in request.meta or ('splash' in request.meta and 'proxy' in request.meta['splash']['args']):
             if request.meta.get("exception", False) is False:
@@ -99,7 +102,7 @@ class RandomProxy(object):
                 proxy_address, len(self.proxies)))
 
     def process_exception(self, request, exception, spider):
-        if 'proxy' not in request.meta and not('splash' in request.meta and 'proxy' in request.meta['splash']['args']):
+        if self.mode < 0 or ('proxy' not in request.meta and not('splash' in request.meta and 'proxy' in request.meta['splash']['args'])):
             return
         if self.mode == Mode.RANDOMIZE_PROXY_EVERY_REQUESTS or self.mode == Mode.RANDOMIZE_PROXY_ONCE:
             if ('splash' in request.meta and 'proxy' in request.meta['splash']['args']):


### PR DESCRIPTION
In the case the virtual browser [splash](https://scrapinghub.com/splash) is being used forward the proxy to it instead of adding it to the HTTP request.

This change allow the usage of splash with proxies managed by scrapy-proxies

In addition this pull request refactor a little bit the code fixing the issue #40 and include pull request #39 .